### PR TITLE
fix: avoid duplicate post-auth navigation

### DIFF
--- a/project 2/src/components/auth/AuthForm.tsx
+++ b/project 2/src/components/auth/AuthForm.tsx
@@ -53,11 +53,6 @@ export function AuthForm({ onAuthSuccess }: AuthFormProps = {}) {
       } else {
         navigate(location.state?.from || '/');
       }
-      if (onAuthSuccess) {
-        onAuthSuccess();
-      } else {
-        navigate(location.state?.from || '/');
-      }
     } catch (err: any) {
       setError(err.message || 'An error occurred');
     } finally {


### PR DESCRIPTION
## Summary
- avoid navigating twice after auth success

## Testing
- `npm run lint` (fails: getRandomElement defined but unused, unexpected any types, etc.)
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_6894bebc77dc8329bbe549190486be96